### PR TITLE
try catch on dynamic files that load before action registry is built

### DIFF
--- a/lib/actionsv2/catalog/ActionDescriptors.js
+++ b/lib/actionsv2/catalog/ActionDescriptors.js
@@ -1,8 +1,12 @@
 const { allFieldsWithDefaults, defaultTransformations } = require('../../schema-utils')
 const FeatureManager = require('../../FeatureManager')
 let lastIdentifier = 0
-
-const AVAILABLE_ACTIONS = require('../../models-dynamic/AvailableActions')
+let AVAILABLE_ACTIONS
+try {
+  AVAILABLE_ACTIONS  = require('../../models-dynamic/AvailableActions')
+} catch (e) {
+  console.log(`Could not load AvailableActions. You may need to run\n new ActionRegistry().build()`)
+}
 
 class ActionDescriptors {
   static forType(typeName) {

--- a/lib/actionsv2/catalog/CredentialTypes.js
+++ b/lib/actionsv2/catalog/CredentialTypes.js
@@ -1,7 +1,13 @@
 const { allFieldsWithDefaults } = require('../../schema-utils')
 
-const AvailableTypes = require('../../models-dynamic/AvailableCredentialsTypes')
-const AVAILABLE_TYPES = AvailableTypes.AVAILABLE_TYPES
+let AvailableTypes
+let AVAILABLE_TYPES
+try {
+  AvailableTypes  = require('../../models-dynamic/AvailableCredentialsTypes')
+  AVAILABLE_TYPES = AvailableTypes.AVAILABLE_TYPES
+} catch (e) {
+  console.log(`Could not load AvailableCredentialsTypes. You may need to run\n new ActionRegistry().build()`)
+}
 
 class CredentialTypes {
   static allTypes() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trivial-core",
-  "version": "1.2.3",
+  "version": "1.2.5",
   "description": "Build event processors to apply business rules",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trivial-core",
-  "version": "1.2.5",
+  "version": "1.3.1",
   "description": "Build event processors to apply business rules",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trivial-core",
-  "version": "1.3.1",
+  "version": "1.2.4",
   "description": "Build event processors to apply business rules",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
If actions have been deleted since the last action registry build, they will fail to load and prevent an app that uses this package from starting. By wrapping them in a try/catch block, the app is able to load and `new ActionRegistry().build()` is able to run and bring the registry and the actions into alignment.