### PR TITLE
wait for nested dirs

### DIFF
--- a/lib/GitManager.js
+++ b/lib/GitManager.js
@@ -55,7 +55,7 @@ class GitManager {
     for (let blob of content) {
       if (blob.type == "dir") {
         fs.mkdir(`${this.local_path}/${blob.path}`, {recursive: true})
-        this.getContent(blob.path)
+        await this.getContent(blob.path)
       } else {
         const file = await this._getContent(blob.path)
         let writePath = path.join(this.local_path, blob.path)


### PR DESCRIPTION
Resolves an issue where the promise resolves when only the outermost directory has been downloaded, and nested directories are still in process.