### PR TITLE
nested action conditions

### DIFF
--- a/changelog.MD
+++ b/changelog.MD
@@ -1,6 +1,8 @@
 
 # Trivial-Core Changelog
 
+## 1.3.3
+- ActionDescriptor can specify a condition that must be met for the action to run
 
 ## 1.3.2
 - Adds support for saving an archived slug to the manifest API on build

--- a/lib/generatorv2/ActionGenerator.js
+++ b/lib/generatorv2/ActionGenerator.js
@@ -61,6 +61,20 @@ class ActionGenerator {
     return out
   }
 
+  _checkConditionGuard() {
+    if (!this.definedCheckCondition) { return ''}
+    return `\n    if (!this.checkCondition()) { return true }\n`
+  }
+
+  get definedCheckCondition() {
+    try {
+      // actions[0] is the transform, actions[1] is the action itself
+      return this.actionDef.definition.actions[1].definition.condition
+    } catch (e) {
+      return false
+    }
+  }
+
   _perform(generators, additionalParams) {
     let _params = this._additionalParams(additionalParams)
     return generators.map((g, idx) => {
@@ -94,6 +108,14 @@ class ActionGenerator {
     }).join("\n")
   }
 
+  _checkConditionMethod() {
+    return `checkCondition() {\n` +
+      "    const payload = Object.assign({}, this.values, this.inputValue)\n" +
+      "    const initialPayload = payload.initialPayload\n" +
+      `    return ${this.definedCheckCondition}\n` +
+      '  }'
+  }
+
   _additionalDefinitions() {
     return ''
   }
@@ -107,10 +129,14 @@ ${this._additionalRequires()}
 
 class ${this.name} extends ActionBase {
   async perform() {
+    ${this._checkConditionGuard()}
     ${this._performActions()}
     return this.canProceed()
   }
+
+  ${this._checkConditionMethod()}
 ${this._actionMethods()}
+
 }
 
 ${this._additionalDefinitions()}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trivial-core",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Build event processors to apply business rules",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
**Before**
To run an action conditionally, you must nest your action in the **Then** block of an **If** action. This breaks the logic across 2 actions, and then 2 screens.
![Screenshot 2023-09-19 at 12 04 00 PM](https://github.com/solid-adventure/trivial-core/assets/80924/6718af77-66e4-4c14-94cd-64b2c24ed64b)

**After**
Actions can define a condition, allowing the conditions and the settings to be displayed on the same page
![Screenshot 2023-09-19 at 12 03 13 PM](https://github.com/solid-adventure/trivial-core/assets/80924/9aa5dd4f-d12b-4fa0-9e38-b323827e523a)


You can set the action to require a condition by returning a `condition` key on `getDefinitionFields`:
```javascript
// /actions/YOUR-SERVICE/YOUR-ACTION/descriptor.js
  getDefinitionFields() {
    return {
      condition: {
        type: String,
        required: true,
        editorComponent: 'Condition',
        placeholder: 'initialPayload.event_name == \'customer_signup\'',
        example: 'initialPayload.event_name == \'customer_signup\'',
        help: 'The condition that must be met for this action to run. If the condition is not met, the action will be skipped.'
      }
    }
  }
```

By additionally setting `editorComponent: 'Condition'`, a special field type is used. Currently this displays a CodeCompletingEditor, but in a future release this will be extended to more clearly represent the pass/fail nature of the filter, compared to a general completion that can return any value.