### PR TITLE
update/builer-writeLocally

### DIFF
--- a/lib/AppBuilder.js
+++ b/lib/AppBuilder.js
@@ -124,9 +124,11 @@ class AppBuilder {
     return `./slugs/${inputManifest.app_id}`
   }
 
-  async writeLocally(inputManifest) {
+  async writeLocally(inputManifest, path) {
     this.logger.debug(`[AppBuilder]    Starting to write '${inputManifest.app_id}'`)
-    let path = this.localPath(inputManifest)
+    if (!path) {
+      path = this.localPath(inputManifest)
+    }
     fs.mkdir(path, {recursive: true})
     const writer = new FileWriter(path)
     await this._assembleCode(inputManifest, true, writer)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trivial-core",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Build event processors to apply business rules",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
**Before**
`writeLocally` always wrote to an internally generated directory path

**After**
`writeLocally` now accepts a `path` as an argument to allow for writing to externally specified directory paths

**Notes**
Non-breaking change due to optionality, `writeLocally` will check for the `path` argument and fallback to previous behavior if not found