### PR TITLE
unsigned cookies

### DIFF
--- a/changelog.MD
+++ b/changelog.MD
@@ -1,6 +1,9 @@
 
 # Trivial-Core Changelog
 
+## 1.6.1
+- Switch to an unsigned cookie to support browser session handling, instead of only the Express server
+
 ## 1.6.0
 - LUPIN_URL renamed to TRIVIAL_UI_URL
 

--- a/lib/APISpec.js
+++ b/lib/APISpec.js
@@ -23,7 +23,7 @@ module.exports = class APISpec {
 		let keys = Object.keys(headers)
 		for (let key of keys) {
 			let prepended = this.prependService(key)
-			res.cookie(prepended, headers[key], {signed: true})
+			res.cookie(prepended, headers[key], {signed: false})
 		}
 	}
 
@@ -33,7 +33,7 @@ module.exports = class APISpec {
     for (let h of this.spec.headers){
     	if (headers[h]) {
 			let prepended = this.prependService(h)
-			res.cookie(prepended, headers[h], {signed: true})
+			res.cookie(prepended, headers[h], {signed: false})
     	}
     }
 	}
@@ -44,11 +44,11 @@ module.exports = class APISpec {
 
 	  let toInject = {}
 	  for (let h of this.spec.headers){
-		if (req.signedCookies[this.prependService(h)]) {
+		if (req.cookies[this.prependService(h)]) {
 			// inject header WITHOUT prepend - access signed cookie WITH prepend
 			let stripped = this.removePrepend(h)
 			let prepended = this.prependService(h)
-			toInject[stripped] = req.signedCookies[prepended]
+			toInject[stripped] = req.cookies[prepended]
 	    }
 	  }
 	  Object.assign(serviceReq.headers, toInject)
@@ -59,10 +59,10 @@ module.exports = class APISpec {
 
 		let toInject= {}
 		for(let qp of this.spec.queryParams){
-			if(req.signedCookies[this.prependService(qp)]){
+			if(req.cookies[this.prependService(qp)]){
 				let stripped = this.removePrepend(qp)
 				let prepended = this.prependService(qp)
-				toInject[stripped] = req.signedCookies[prepended]
+				toInject[stripped] = req.cookies[prepended]
 			}
 		}
 		serviceReq.url = this.appendQueryParameters(serviceReq.url, toInject)
@@ -79,7 +79,7 @@ module.exports = class APISpec {
 
   isResetRequest(req, serviceReq) {
     return this.spec.resetHeader &&
-      req.signedCookies[this.prependService(this.spec.resetHeader)] &&
+      req.cookies[this.prependService(this.spec.resetHeader)] &&
       this.isAllowedServiceCall(serviceReq)
   }
 
@@ -92,14 +92,14 @@ module.exports = class APISpec {
   }
 
   injectResetHeaders(req, serviceReq) {
-    const headers = JSON.parse(req.signedCookies[this.prependService(this.spec.resetHeader)])
+    const headers = JSON.parse(req.cookies[this.prependService(this.spec.resetHeader)])
     this.spec.headers.forEach(h => serviceReq.headers[h] = headers[h])
   }
 
 	serviceListMissingHeaders(req) {
 		let undefined_headers = []
 		for (let h of this.spec.headers){
-			if(req.signedCookies[this.prependService(h)] == undefined){
+			if(req.cookies[this.prependService(h)] == undefined){
 				undefined_headers.push(h)
 			}
 		}
@@ -109,7 +109,7 @@ module.exports = class APISpec {
 	serviceListMissingQueryParams(req){
 		let undefined_queryParams = []
 		for (let qp of this.spec.queryParams){
-			if(req.signedCookies[this.prependService(qp)] == undefined){
+			if(req.cookies[this.prependService(qp)] == undefined){
 				undefined_queryParams.push(qp)
 			}
 		}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trivial-core",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Build event processors to apply business rules",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Switch to an unsigned cookie to support browser session handling, instead of only the Express server
