### PR TITLE
declare custom functions as utils

### DIFF
--- a/changelog.MD
+++ b/changelog.MD
@@ -1,6 +1,9 @@
 
 # Trivial-Core Changelog
 
+## 1.6.2
+- Adds support for using custom functions in action conditions
+
 ## 1.6.1
 - Switch to an unsigned cookie to support browser session handling, instead of only the Express server
 

--- a/lib/generatorv2/ActionGenerator.js
+++ b/lib/generatorv2/ActionGenerator.js
@@ -112,6 +112,7 @@ class ActionGenerator {
     return `checkCondition() {\n` +
       "    const payload = Object.assign({}, this.values, this.inputValue)\n" +
       "    const initialPayload = payload.initialPayload\n" +
+      `    ${this.factory.referenceManager.referenceDeclarations(this.definedCheckCondition)}\n` + // const customFunction() = $utils.customFunction()
       `    return ${this.definedCheckCondition}\n` +
       '  }'
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trivial-core",
-  "version": "1.6.0",
+  "version": "1.6.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "trivial-core",
-      "version": "1.6.0",
+      "version": "1.6.2",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-cloudwatch-logs": "^3.28.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trivial-core",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "Build event processors to apply business rules",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
**Before**
Using a custom function in an action condition throw a not defined error. The generator produces:

```javascript
  checkCondition() {
    const payload = Object.assign({}, this.values, this.inputValue)
    const initialPayload = payload.initialPayload
    return sayHi(initialPayload)
  }
// checkCondition()
// sayHi is not defined

```

**After**

Custom functions work as expected in action conditions. This is due to the action generator now including a definition that makes the custom functions available in the context they are called, similar to Transforms. The generator produces:

```javascript
  checkCondition() {
    const payload = Object.assign({}, this.values, this.inputValue)
    const initialPayload = payload.initialPayload
    const sayHi = $utils.sayHi
    return sayHi(initialPayload)
  }

// checkCondition()
// Hi there!

```


