### PR TITLE
declare once, and only once

### DIFF
--- a/changelog.MD
+++ b/changelog.MD
@@ -1,11 +1,9 @@
 
 # Trivial-Core Changelog
 
-## 1.6.3
-- Fixes a bug where custom functions in action conditions throw $utils is not defined
-
-## 1.6.2
+## 1.6.4
 - Adds support for using custom functions in action conditions
+- Replaces 1.6.2 and 1.6.3, with subtly broken versions of this feature
 
 ## 1.6.1
 - Switch to an unsigned cookie to support browser session handling, instead of only the Express server

--- a/changelog.MD
+++ b/changelog.MD
@@ -3,7 +3,7 @@
 
 ## 1.6.4
 - Adds support for using custom functions in action conditions
-- Replaces 1.6.2 and 1.6.3, with subtly broken versions of this feature
+- Replaces 1.6.2 and 1.6.3, with slightly broken versions of this feature
 
 ## 1.6.1
 - Switch to an unsigned cookie to support browser session handling, instead of only the Express server

--- a/lib/generatorv2/ActionGenerator.js
+++ b/lib/generatorv2/ActionGenerator.js
@@ -42,7 +42,7 @@ class ActionGenerator {
   _additionalRequires() {
     return this._unique(
       this.generators.map(g => g.requireExpression())
-      .concat(this.factory.referenceManager.requireStatements())
+      .concat(this.factory.referenceManager.referenceDeclarations(this.definedCheckCondition)) // const customFunction() = $utils.customFunction()
     ).join('\n')
   }
 
@@ -115,7 +115,6 @@ class ActionGenerator {
     return `checkCondition() {\n` +
       "    const payload = Object.assign({}, this.values, this.inputValue)\n" +
       "    const initialPayload = payload.initialPayload\n" +
-      `    ${this.factory.referenceManager.referenceDeclarations(this.definedCheckCondition)}\n` + // const customFunction() = $utils.customFunction()
       `    return ${this.definedCheckCondition}\n` +
       '  }'
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trivial-core",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "trivial-core",
-      "version": "1.6.3",
+      "version": "1.6.4",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-cloudwatch-logs": "^3.28.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
-{
+ {
   "name": "trivial-core",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "description": "Build event processors to apply business rules",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
**Before**
All demo of custom functions in conditions appeared to work, but tests fail with variations of `'$utils' has already been declared`

**After**
After some waggling back and forth declaring $utils not at all or multiple times, this uses the approach discovered in https://github.com/solid-adventure/trivial-core/pull/30, but applies it once for the file, in a manner that prevents duplication.

Tests are passing and demo envs appear to work as expected. 