### PR TITLE
enhance/log-register-item-ids

### DIFF
--- a/changelog.MD
+++ b/changelog.MD
@@ -1,6 +1,9 @@
 
 # Trivial-Core Changelog
 
+## 1.6.5
+- Adds support for relating ActivityEntries to RegisterItems in trivial-api
+
 ## 1.6.4
 - Adds support for using custom functions in action conditions
 - Replaces 1.6.2 and 1.6.3, with slightly broken versions of this feature

--- a/lib/ActivityEntry.js
+++ b/lib/ActivityEntry.js
@@ -8,6 +8,7 @@ class ActivityEntry {
     this.logToUrl = `${logToUrl}/webhooks`
     this.source = source
     this.startTime = Date.now()
+    this.registerItemId = null
   }
 
   logEvent(event, success, detail) {
@@ -64,7 +65,8 @@ class ActivityEntry {
       diagnostics: {
         errors: this.serializedErrors,
         events: this.diagnostics.events
-      }
+      },
+      register_item_id: this.registerItemId
     }
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trivial-core",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "trivial-core",
-      "version": "1.6.4",
+      "version": "1.6.5",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-cloudwatch-logs": "^3.28.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
  {
   "name": "trivial-core",
-  "version": "1.6.4",
+  "version": "1.6.5",
   "description": "Build event processors to apply business rules",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
**Before**
`ActivityEntries` were no relation to `RegisterItems` 

**After**
`ActivityEntries` now store a `registerItemId` that is used to update and relate the entry to `RegsiterItems` when a log finishes