### PR TITLE
Async functions do not trigger syntax errors

### DIFF
--- a/changelog.MD
+++ b/changelog.MD
@@ -1,6 +1,9 @@
 
 # Trivial-Core Changelog
 
+## 1.6.8
+- Async functions do not trigger syntax errors in CodeCompletionGenerator
+
 ## 1.6.7
 - bumps jwt dependencies to 9.0.0
 

--- a/lib/CodeCompletionGenerator.js
+++ b/lib/CodeCompletionGenerator.js
@@ -11,7 +11,7 @@ class CodeCompletionGenerator {
   //  - blocks: blocks of custom function definitions available to this code (optional)
   //  - singleExpression: if true (the default), parses only the first expression. set to false for multi-line or multi-expression input.
   constructor(expression, options) {
-    this.SUPPORTED_ECMA_VERSION = 6
+    this.SUPPORTED_ECMA_VERSION = 8
     this.expression = expression
     this.options = Object.assign({
       insertionCol: -1,
@@ -67,6 +67,10 @@ class CodeCompletionGenerator {
       return undefined
     }
 
+    if (this.isAsync()) {
+      return undefined
+    }
+
     try {
       return new Function(
         'payload',
@@ -75,7 +79,6 @@ class CodeCompletionGenerator {
         `with (payload) { return ${this.expression} }`
       )(this.baseDataSample())
     } catch (error) {
-      // console.log(error)
       this.referenceError = error
       return undefined
     }
@@ -92,6 +95,13 @@ class CodeCompletionGenerator {
       'Program' === this.ast.type &&
       1 == this.ast.body.length &&
       'ExpressionStatement' == this.ast.body[0].type
+  }
+
+  isAsync() {
+    return this.ast &&
+      ('Program' === this.ast.type &&
+      this.ast.body[0].async) ||
+      ('Identifier' == this.ast.type && 'await' === this.ast.name)
   }
 
   isLiteral() {
@@ -149,6 +159,10 @@ class CodeCompletionGenerator {
     let functionName = this.firstDefinedFunctionName()
     if (! functionName) {
       return undefined
+    }
+
+    if (this.isAsync()) {
+      return "Preview is not supported for async functions. You must run your app to see the result of this function."
     }
 
     try {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trivial-core",
-  "version": "1.6.7",
+  "version": "1.6.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "trivial-core",
-      "version": "1.6.7",
+      "version": "1.6.8",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-cloudwatch-logs": "^3.28.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
  {
   "name": "trivial-core",
-  "version": "1.6.7",
+  "version": "1.6.8",
   "description": "Build event processors to apply business rules",
   "main": "index.js",
   "scripts": {

--- a/test/lib/CodeCompletionGenerator.js
+++ b/test/lib/CodeCompletionGenerator.js
@@ -8,7 +8,15 @@ const {
 
 describe('CodeCompletionGenerator', () => {
 
+
+
   describe('._path', () => {
+
+    it('identifies an async function', () => {
+      let gen = new CodeCompletionGenerator('async function foo() { return 42 }', {singleExpression: false})
+      expect(gen.isAsync()).to.be.true
+    })
+
     it('produces an empty path for an empty string', () => {
       expect(path(new CodeCompletionGenerator(''))).to.be.null
     })
@@ -251,6 +259,11 @@ describe('CodeCompletionGenerator', () => {
       dataSample: {order: {id: 1234, status: 'picked', total_amt: '100.00'}}
     }
 
+    it('does not evaluate an async function', async () => {
+      let gen = new CodeCompletionGenerator('async function foo() { return 42 }', {singleExpression: false})
+      expect(await gen.evaluatesAs()).to.be.undefined
+    })
+
     it('returns the expression value when it is valid', () => {
       let gen = new CodeCompletionGenerator('order.status', opts)
       expect(gen.evaluatesAs()).to.eq('picked')
@@ -393,6 +406,13 @@ describe('CodeCompletionGenerator', () => {
   })
 
   describe(".firstDefinedFunctionName()", () => {
+
+    it('identifies the name of an async function', () => {
+      let gen = new CodeCompletionGenerator('async function foo() { return 42 }', {singleExpression: false})
+      expect(gen.firstDefinedFunctionName()
+      ).to.eql('foo')
+    })
+
     it('identifies function declaration names', () => {
       expect(
         new CodeCompletionGenerator('function foo() { }', {singleExpression: false})


### PR DESCRIPTION
**Before**
Using async functions in the UI throws syntax errors 
![before - function editing](https://github.com/user-attachments/assets/acb38442-7fad-4889-844d-517145521f5a)
![before - output attributes](https://github.com/user-attachments/assets/724a5cdc-9a5a-4653-9771-e00f12240041)


---------



**After**
Async functions do not provide a preview, but neither do they trigger a false-positive syntax error. Non-async functions continue to work as expected.     
![after - output attributes](https://github.com/user-attachments/assets/196ab168-825a-4c78-9d5d-fbb63a1e81ae)
![after - function editing, normal](https://github.com/user-attachments/assets/c57c13b8-ab89-4126-8970-84ce503a53f7)
![after - function editing](https://github.com/user-attachments/assets/8676290c-2b1c-4b0a-9711-0302270b677c)
